### PR TITLE
fix: pin pulp version for snakemake <8.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+pulp<2.8
 hydra-genetics==1.8.1
 pandas>=1.3.1
-snakemake>=7.32
+snakemake~=7.32
 singularity==3.0.0
 jinja2==3.0.1
 networkx


### PR DESCRIPTION
An API change in pulp results in old versions of Snakemake breaking. Pinning the pulp version to <2.8 addresses this until we upgrade to a newer version of Snakemake.