### PR TITLE
ci: update the checkout action to v4

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,18 +1,11 @@
 name: Lint
 
-# Controls when the action will run.
 on:
-   # Triggers the workflow on push or pull request events but only for the master and develop branch
-  push:
-    branches:
-     - dev
-     - main
   pull_request:
     branches:
      - dev
      - main
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
@@ -21,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/pycodestyle.yaml
+++ b/.github/workflows/pycodestyle.yaml
@@ -1,18 +1,11 @@
 name: pycodestyle
 
-# Controls when the action will run.
 on:
-   # Triggers the workflow on push or pull request events but only for the master and develop branch
-  push:
-    branches:
-     - dev
-     - main
   pull_request:
     branches:
      - dev
      - main
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
@@ -20,7 +13,7 @@ jobs:
     name: pycodestyle
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,18 +1,11 @@
 name: pytest
 
-# Controls when the action will run.
 on:
-   # Triggers the workflow on push or pull request events but only for the master and develop branch
-  push:
-    branches:
-     - dev
-     - main
   pull_request:
     branches:
      - dev
      - main
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
@@ -20,7 +13,7 @@ jobs:
     name: pytest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/snakefmt.yaml
+++ b/.github/workflows/snakefmt.yaml
@@ -1,18 +1,11 @@
 name: Snakefmt
 
-# Controls when the action will run.
 on:
-   # Triggers the workflow on push or pull request events but only for the master and develop branch
-  push:
-    branches:
-     - dev
-     - main
   pull_request:
     branches:
      - dev
      - main
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
@@ -21,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Lint Code Base

--- a/.github/workflows/snakemake-dry-run.yaml
+++ b/.github/workflows/snakemake-dry-run.yaml
@@ -1,18 +1,11 @@
 name: Snakemake dry run
 
-# Controls when the action will run.
 on:
-   # Triggers the workflow on push or pull request events but only for the master and develop branch
-  push:
-    branches:
-     - dev
-     - main
   pull_request:
     branches:
      - dev
      - main
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
@@ -20,7 +13,7 @@ jobs:
     name: Run snakemake dry run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Also set most actions to only run on PRs to main and dev. Since both of these branches should be write-protected, this would simply mean duplicated runs for actions that were set to run on both push and PR to these branches.