### PR TITLE
feat: better copy-number thresholds for hematology

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -54,6 +54,9 @@ cnvkit_call:
 
 cnvkit_vcf:
   container: "docker://hydragenetics/cnvkit:0.9.9"
+  hom_del_limit: 0.47
+  het_del_limit: 1.68
+  dup_limit: 2.3
 
 fastp_pe:
    container: "docker://hydragenetics/fastp:0.20.1"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -54,9 +54,9 @@ cnvkit_call:
 
 cnvkit_vcf:
   container: "docker://hydragenetics/cnvkit:0.9.9"
-  hom_del_limit: 0.47
-  het_del_limit: 1.68
-  dup_limit: 2.3
+  hom_del_limit: "0.47"
+  het_del_limit: "1.68"
+  dup_limit: "2.3"
 
 fastp_pe:
    container: "docker://hydragenetics/fastp:0.20.1"


### PR DESCRIPTION
This uses the [default thresholds for CNVkit](https://cnvkit.readthedocs.io/en/stable/pipeline.html#calling-methods), and should be a better fit for hematology since the tumor cell content generally is higher.

Closes #44