### PR TITLE
feat: make tumor content optional

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -98,7 +98,7 @@ multiqc:
         - N
       qc_files:
         - "qc/fastqc/{sample}_{type}_{flowcell}_{lane}_{barcode}_{read}_fastqc.zip"
-        - "prealignment/fastp_pe/{sample}_{flowcell}_{lane}_{barcode}_{type}.json"
+        - "prealignment/fastp_pe/{sample}_{type}_{flowcell}_{lane}_{barcode}_fastp.json"
         - "qc/mosdepth_bed/{sample}_{type}.mosdepth.summary.txt"
         - "qc/mosdepth_bed/{sample}_{type}.per-base.bed.gz"
         - "qc/picard_collect_hs_metrics/{sample}_{type}.HsMetrics.txt"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -162,8 +162,8 @@ pindel_call:
   extra: "-x 2 -B 60" #x och B?
   include_bed: "/projects/wp2/nobackup/Twist_Myeloid/Bed_files/twist_shortlist_pindel-201214.bed"
 
-pindel_update_vcf_sequence_dictionary:
-  container: "docker://hydragenetics/picard:2.25.0"
+pindel_update_vcf:
+  container: "docker://hydragenetics/picard:2.25.4"
 
 pindel2vcf:
   container: "docker://hydragenetics/pindel:0.2.5b9"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -82,7 +82,7 @@ module prealignment:
         github(
             "hydra-genetics/prealignment",
             path="workflow/Snakefile",
-            tag="v0.3.1",
+            tag="v1.2.0",
         )
     config:
         config

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -23,7 +23,7 @@ module alignment:
         github(
             "hydra-genetics/alignment",
             path="workflow/Snakefile",
-            tag="v0.2.0",
+            tag="v0.5.1",
         )
     config:
         config

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -53,7 +53,7 @@ validate(config, schema="../schemas/resources.schema.yaml")
 
 ### Read and validate samples file
 
-samples = pd.read_table(config["samples"], dtype=str, comment="#").set_index("sample", drop=False)
+samples = pd.read_table(config["samples"], comment="#").set_index("sample", drop=False)
 validate(samples, schema="../schemas/samples.schema.yaml")
 
 ### Read and validate units file

--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -7,9 +7,8 @@ properties:
     description: sample id
 
   tumor_content:
-    type: string
+    type: ["number", "null"]
     description: tumor cell content in sample
 
 required:
   - sample
-  - tumor_content


### PR DESCRIPTION
This PR makes use of new functionality in the cnv_sv module that allows for the tumor content to be optional.

Closes #46 