### PR TITLE
fix: incorrect type for copy number thresholds

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -54,9 +54,9 @@ cnvkit_call:
 
 cnvkit_vcf:
   container: "docker://hydragenetics/cnvkit:0.9.9"
-  hom_del_limit: "0.47"
-  het_del_limit: "1.68"
-  dup_limit: "2.3"
+  hom_del_limit: 0.47
+  het_del_limit: 1.68
+  dup_limit: 2.3
 
 fastp_pe:
    container: "docker://hydragenetics/fastp:0.20.1"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -48,7 +48,7 @@ use rule * from annotation as annotation_*
 
 module cnv_sv:
     snakefile:
-        github("hydra-genetics/cnv_sv", path="workflow/Snakefile", tag="v0.4.1")
+        github("hydra-genetics/cnv_sv", path="workflow/Snakefile", tag="b549266")
     config:
         config
 


### PR DESCRIPTION
This is a bug that should have been caught already in #53. It is related to an [issue in cnv_sv](https://github.com/hydra-genetics/cnv_sv/issues/163) where the types of the default thresholds mismatched with config-defined thresholds.

For now I'm going with a commit for the cnv_sv version instead of waiting for a new release of the module.