### PR TITLE
refactor: add POPPY_HOME variable to config

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,4 +29,5 @@ jobs:
         run: |
           snakemake -s ../../workflow/Snakefile \
             --configfile ../../config/config.yaml config/config.yaml \
+            --config POPPY_HOME=../.. \
             --lint

--- a/.github/workflows/snakemake-dry-run.yaml
+++ b/.github/workflows/snakemake-dry-run.yaml
@@ -26,4 +26,4 @@ jobs:
       - name: snakemake dry run
         working-directory: .tests/integration
         run: |
-          snakemake -n -s ../../workflow/Snakefile --configfile ../../config/config.yaml config/config.yaml
+          snakemake -n -s ../../workflow/Snakefile --configfile ../../config/config.yaml config/config.yaml --config POPPY_HOME=../..

--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -1,8 +1,4 @@
 ---
-
-output: "../../config/output_files.yaml"
-resources: "../../config/resources.yaml"
-
 reference:
   fasta: "reference/hg19.fasta"
   fai: "reference/hg19.fasta.fai"
@@ -11,9 +7,6 @@ reference:
   design_bed: "data/bed/design.bed"
   design_intervals_gatk_cnv: "data/bed/design.bed"
   artifacts: "reference/artifact_panel.tsv"
-
-annotate_cnv:
-  cnv_genes: ../../config/cnv_genes.hg19.bed
 
 bwa_mem:
   amb: "reference/hg19.fasta.amb"
@@ -28,27 +21,11 @@ cnv_html_report:
 cnvkit_batch:
   normal_reference: "data/cnvkit/cnvkit_pon.cnn"
 
-filter_vcf:
-  germline: "../../config/config_hard_filter_germline.yaml"
-  somatic: "../../config/config_soft_filter_somatic.yaml"
-  pindel: "../../config/config_soft_filter_pindel.yaml"
-  cnv_hard_filter_amp: "../../config/config_hard_filter_cnv_amp.yaml"
-  cnv_hard_filter_loh: "../../config/config_hard_filter_cnv_loh.yaml"
-
 gatk_collect_allelic_counts:
   SNP_interval: "data/gatk/gnomad_SNP_0.001_target.annotated.interval_list"
 
 gatk_denoise_read_counts:
   normal_reference: "data/gatk/pon.hdf5"
-
-merge_cnv_json:
-  annotations:
-    - ../../config/cnv_genes.hg19.bed
-
-multiqc:
-  reports:
-    DNA:
-      config: "../../config/multiqc.yaml"
 
 pindel_call:
   include_bed: "data/bed/pindel_regions.bed"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,8 +1,8 @@
 ---
-resources: "config/resources.yaml"
+resources: "{{POPPY_HOME}}/config/resources.yaml"
 samples: "samples.tsv"
 units: "units.tsv"
-output: "config/output_files.yaml"
+output: "{{POPPY_HOME}}/config/output_files.yaml"
 
 default_container: "docker://hydragenetics/common:1.10.2"
 
@@ -20,7 +20,7 @@ reference:
     - "chrM"
 
 annotate_cnv:
-  cnv_genes: config/cnv_genes.hg19.bed
+  cnv_genes: "{{POPPY_HOME}}/config/cnv_genes.hg19.bed"
 
 bcbio_variation_recall_ensemble:
   container: "docker://hydragenetics/bcbio-vc:0.2.6"
@@ -64,11 +64,11 @@ fastqc:
   container: "docker://hydragenetics/fastqc:0.11.9"
 
 filter_vcf:
-  germline: "config/config_hard_filter_germline.yaml"
-  somatic: "config/config_soft_filter_somatic.yaml"
-  pindel: "config/config_soft_filter_pindel.yaml"
-  cnv_hard_filter_amp: "config/config_hard_filter_cnv_amp.yaml"
-  cnv_hard_filter_loh: "config/config_hard_filter_cnv_loh.yaml"
+  germline: "{{POPPY_HOME}}/config/config_hard_filter_germline.yaml"
+  somatic: "{{POPPY_HOME}}/config/config_soft_filter_somatic.yaml"
+  pindel: "{{POPPY_HOME}}/config/config_soft_filter_pindel.yaml"
+  cnv_hard_filter_amp: "{{POPPY_HOME}}/config/config_hard_filter_cnv_amp.yaml"
+  cnv_hard_filter_loh: "{{POPPY_HOME}}/config/config_hard_filter_cnv_loh.yaml"
 
 gatk_collect_allelic_counts:
   container: "docker://hydragenetics/gatk4:4.1.9.0"
@@ -100,7 +100,7 @@ mark_duplicates:
 
 merge_cnv_json:
   annotations:
-    - config/cnv_genes.hg19.bed
+    - "{{POPPY_HOME}}/config/cnv_genes.hg19.bed"
   germline_vcf: snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.vcf.gz
   filtered_cnv_vcfs:
     - cnv_sv/svdb_query/{sample}_{type}.{tc_method}.svdb_query.annotate_cnv.cnv_genes.filter.cnv_hard_filter_amp.vcf.gz
@@ -115,7 +115,7 @@ multiqc:
   container: "docker://hydragenetics/multiqc:1.21"
   reports:
     DNA:
-      config: "config/multiqc.yaml"
+      config: "{{POPPY_HOME}}/config/multiqc.yaml"
       included_unit_types:
         - T
         - N

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -28,6 +28,7 @@ hydra_min_version("1.8.1")
 min_version("7.32.0")
 
 from datetime import datetime
+from hydra_genetics.utils.misc import replace_dict_variables
 from hydra_genetics.utils.misc import export_config_as_file
 from hydra_genetics.utils.software_versions import add_version_files_to_multiqc
 from hydra_genetics.utils.software_versions import add_software_version_to_config
@@ -66,6 +67,9 @@ onstart:
 
 if not workflow.overwrite_configfiles:
     sys.exit("At least one config file must be passed using --configfile/" "--configfiles, by command line or a profile!")
+
+
+config = replace_dict_variables(config)
 
 try:
     validate(config, schema="../schemas/config.schema.yaml")


### PR DESCRIPTION
Add a POPPY_HOME varible to be set in config for a more varible configfile

For snakemake dry run running in `.test/integration` the command would be:
`snakemake -n -s ../../workflow/Snakefile --configfile ../../config/config.yaml config/config.yaml --config POPPY_HOME=../..`