### PR TITLE
fix: add bam-files to purecn rules where bamlist is used

### DIFF
--- a/workflow/Snakefile_references.smk
+++ b/workflow/Snakefile_references.smk
@@ -112,9 +112,19 @@ use rule purecn_coverage from references as references_purecn_coverage with:
     input:
         bam_list_file="references/purecn_bam_list/bam_files.list",
         intervals="references/purecn_interval_file/targets_intervals.txt",
+        bam_files=get_bams(),
+        bai_files=get_bais(),
     params:
         intervals="references/purecn_interval_file/targets_intervals.txt",
         extra=config.get("purecn_coverage", {}).get("extra", ""),
+
+
+use rule purecn_normal_db from references as references_purecn_normal_db with:
+    input:
+        coverage_list_file="references/purecn_coverage_list/coverage_files.list",
+        coverage_files=get_coverage_files(samples, units),
+        normal_vcf="references/bcftools_merge/normal_db.vcf.gz",
+        normal_vcf_tbi="references/bcftools_merge/normal_db.vcf.gz.tbi",
 
 
 # background

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -48,6 +48,19 @@ def get_bams():
     return list(set([f"alignment/samtools_merge_bam/{t.sample}_{t.type}.bam" for t in units.itertuples()]))
 
 
+def get_bais():
+    return list(set([f"alignment/samtools_merge_bam/{t.sample}_{t.type}.bam.bai" for t in units.itertuples()]))
+
+
+def get_coverage_files(samples, units):
+    coverage_list = [
+        "references/purecn_coverage/%s_%s_coverage_loess.txt.gz" % (sample, unit_type)
+        for sample in get_samples(samples)
+        for unit_type in get_unit_types(units, sample)
+    ]
+    return coverage_list
+
+
 def get_cnv_vcfs():
     return list(set([f"cnv_sv/svdb_merge/{t.sample}_{t.type}.pathology.merged.vcf" for t in units.itertuples()]))
 


### PR DESCRIPTION
`purecn_coverage` rule uses `bam_files.list` as input which contains bam-files, if running the reference pipeline (without `--notemp`) there is a risk that the bamfiles are deleted before the rule is executed. Same thing with `purecn_normal_db` but there it is the coverage files in `coverage_files.list`