### PR TITLE
fix: set custom pick order for VEP

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -206,7 +206,7 @@ vep:
   container: "docker://hydragenetics/vep:111.0"
   vep_cache: ""
   mode: "--offline --cache --merged "
-  extra: " --assembly GRCh38 --check_existing --pick --variant_class --everything "
+  extra: " --assembly GRCh38 --check_existing --pick --variant_class --everything --pick_order mane_select,mane_plus_clinical,canonical,biotype,rank,appris,tsl,ccds,length,ensembl,refseq"
   # vep109: VEP:gnomAD_${pop}e or g for exome/genome. Both --af_gnomade and --af_gnomadg included in everything
   #extra: " --assembly GRCh37 --check_existing --pick --sift b --polyphen b --ccds --uniprot --hgvs --symbol --numbers --domains --regulatory --canonical --protein --biotype --uniprot --tsl --appris --gene_phenotype --af --af_1kg --af_gnomad --max_af --pubmed --variant_class "
 


### PR DESCRIPTION
fix: set custom pick order for VEP

Rank criteria for picking VEP annotation for each variant. Ranking by order of importance:

    1. MANE Select transcript status
    2. MANE Plus Clinical transcript status
    3. canonical status of transcript
    4.  biotype of transcript ("protein_coding" preferred)
    5. consequence rank by order of severity according to http://www.ensembl.org/info/genome/variation/prediction/predicted_data.html#consequences
    6. APPRIS isoform annotation
    7. transcript support level
    8. CCDS status of transcript
    9. translated, transcript or feature length (longer preferred)