### PR TITLE
fix: write blank CSQ for pindel variants skipped by VEP

### DIFF
--- a/docs/softwares.md
+++ b/docs/softwares.md
@@ -28,6 +28,25 @@ Rules specifically for Poppy listed here.
 
 ### :snake: Rule
 
+#SNAKEMAKE_RULE_SOURCE__pindel_processing__pindel_processing_add_missing_csq#
+
+#### :left_right_arrow: input / output files
+
+#SNAKEMAKE_RULE_TABLE__pindel_processing__pindel_processing_add_missing_csq#
+
+### :wrench: Configuration
+
+#### Software settings (`config.yaml`)
+
+#CONFIGSCHEMA__pindel_processing_add_missing_csq#
+
+#### Resources settings (`resources.yaml`)
+
+#RESOURCESSCHEMA__pindel_processing_add_missing_csq#
+
+
+### :snake: Rule
+
 #SNAKEMAKE_RULE_SOURCE__pindel_processing__pindel_processing_fix_af#
 
 #### :left_right_arrow: input / output files
@@ -108,3 +127,6 @@ Software used specifically to create the reference-files for Poppy.
 #### Resources settings (`resources.yaml`)
 
 #RESOURCESSCHEMA__reference_rules_create_artefact_file_pindel#
+
+
+

--- a/workflow/rules/pindel_processing.smk
+++ b/workflow/rules/pindel_processing.smk
@@ -39,8 +39,8 @@ rule pindel_processing_annotation_vep:
 
 rule pindel_processing_artifact_annotation:
     input:
-        vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.vcf.gz",
-        tbi="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.vcf.gz.tbi",
+        vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.csq_corrected.vcf.gz",
+        tbi="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.csq_corrected.vcf.gz.tbi",
         artifacts=config["reference"]["artifacts_pindel"],
     output:
         vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.artifact_annotated.vcf",
@@ -99,3 +99,37 @@ rule pindel_processing_fix_af:
         "{rule}: add af and dp to info field in {input.vcf}"
     script:
         "../scripts/pindel_processing_fix_af.py"
+
+
+rule pindel_processing_add_missing_csq:
+    input:
+        vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.vcf.gz",
+        tbi="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.vcf.gz.tbi",
+    output:
+        vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.csq_corrected.vcf",
+    params:
+        field="CSQ",
+        extra=config.get("pindel_processing_add_missing_csq", {}).get("extra", ""),
+    log:
+        "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.csq_corrected.vcf.log",
+    benchmark:
+        repeat(
+            "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.csq_corrected.vcf.benchmark.tsv",
+            config.get("pindel_processing_add_missing_csq", {}).get("benchmark_repeats", 1),
+        )
+    threads:
+        config.get("pindel_processing_add_missing_csq", {}).get("threads", config["default_resources"]["threads"])
+    resources:
+        mem_mb=config.get("pindel_processing_add_missing_csq", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
+        mem_per_cpu=config.get("pindel_processing_add_missing_csq", {}).get(
+            "mem_per_cpu", config["default_resources"]["mem_per_cpu"]
+        ),
+        partition=config.get("pindel_processing_add_missing_csq", {}).get("partition", config["default_resources"]["partition"]),
+        threads=config.get("pindel_processing_add_missing_csq", {}).get("threads", config["default_resources"]["threads"]),
+        time=config.get("pindel_processing_add_missing_csq", {}).get("time", config["default_resources"]["time"]),
+    container:
+        config.get("pindel_processing_add_missing_csq", {}).get("container", config["default_container"])
+    message:
+        "{rule}: if need be, add missing CSQ annotation to variants in {input.vcf}"
+    script:
+        "../scripts/pindel_processing_add_missing_csq.py"

--- a/workflow/rules/pindel_processing.smk
+++ b/workflow/rules/pindel_processing.smk
@@ -117,8 +117,7 @@ rule pindel_processing_add_missing_csq:
             "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.csq_corrected.vcf.benchmark.tsv",
             config.get("pindel_processing_add_missing_csq", {}).get("benchmark_repeats", 1),
         )
-    threads:
-        config.get("pindel_processing_add_missing_csq", {}).get("threads", config["default_resources"]["threads"])
+    threads: config.get("pindel_processing_add_missing_csq", {}).get("threads", config["default_resources"]["threads"])
     resources:
         mem_mb=config.get("pindel_processing_add_missing_csq", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
         mem_per_cpu=config.get("pindel_processing_add_missing_csq", {}).get(

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -842,7 +842,6 @@ properties:
     required:
       - container
 
-
 required:
   - bcbio_variation_recall_ensemble
   - bwa_mem

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -628,6 +628,20 @@ properties:
     required:
       - container
 
+  pindel_processing_add_missing_csq:
+    type: object
+    description: parameters for pindel_processing_add_missing_csq
+    properties:
+      benchmark_repeats:
+        type: integer
+        description: set number of times benchmark should be repeated
+      container:
+        type: string
+        description: name or path to docker/singularity container
+      extra:
+        type: string
+        description: parameters that should be forwarded
+
   pindel_processing_annotation_vep:
     type: object
     description: parameters for annotation with vep on pindel vcf, most taken from vep rule to ensure that pindel result is processed identical to snvs
@@ -827,6 +841,7 @@ properties:
         format: uri-reference
     required:
       - container
+
 
 required:
   - bcbio_variation_recall_ensemble

--- a/workflow/schemas/resources.schema.yaml
+++ b/workflow/schemas/resources.schema.yaml
@@ -24,6 +24,26 @@ properties:
   required:
     - default_resources
 
+  pindel_processing_add_missing_csq:
+    type: object
+    description: resource definitions for pindel_processing_add_missing_csq
+    properties:
+      mem_mb:
+        type: integer
+        description: max memory in MB to be available
+      mem_per_cpu:
+        type: integer
+        description: memory in MB used per cpu
+      partition:
+        type: string
+        description: partition to use on cluster
+      threads:
+        type: integer
+        description: number of threads to be available
+      time:
+        type: string
+        description: max execution time
+
   pindel_processing_annotation_vep:
     type: object
     description: resource definitions for pindel_processing_annotation_vep, all resources taken from config["vep"]
@@ -103,3 +123,5 @@ properties:
       time:
         type: string
         description: max execution time
+
+

--- a/workflow/schemas/resources.schema.yaml
+++ b/workflow/schemas/resources.schema.yaml
@@ -124,4 +124,3 @@ properties:
         type: string
         description: max execution time
 
-

--- a/workflow/schemas/rules.schema.yaml
+++ b/workflow/schemas/rules.schema.yaml
@@ -2,6 +2,28 @@ $schema: "http://json-schema.org/draft-04/schema#"
 description: snakemake rule input and output files description file
 type: object
 properties:
+  pindel_processing_add_missing_csq:
+    type: object
+    description: input and output parameters for pindel_processing_add_missing_csq
+    properties:
+      input:
+        type: object
+        description: list of inputs
+        properties:
+          vcf:
+            type: string
+            description: gzipped vcf to be corrected for missing CSQ
+          tbi:
+            type: string
+            description: tbi index to input.vcf
+      output:
+        type: object
+        description: list of outputs
+        properties:
+          vcf:
+            type: string
+            description: annotated vcf file with blank CSQ if needed
+
   pindel_processing_annotation_vep:
     type: object
     description: input and output parameters for vep annotation of pindel vcf
@@ -114,3 +136,4 @@ properties:
           vcf:
             type: string
             description: a 'vcf' file containing the merged SV calls
+

--- a/workflow/schemas/rules.schema.yaml
+++ b/workflow/schemas/rules.schema.yaml
@@ -136,4 +136,3 @@ properties:
           vcf:
             type: string
             description: a 'vcf' file containing the merged SV calls
-

--- a/workflow/scripts/pindel_processing_add_missing_csq.py
+++ b/workflow/scripts/pindel_processing_add_missing_csq.py
@@ -1,13 +1,5 @@
-from collections import OrderedDict
-import gzip
 import logging
 from pysam import VariantFile
-
-from hydra_genetics.utils.io.chr import ChrTranslater
-from hydra_genetics.utils.models.hotspot import MultiBpVariantData
-from hydra_genetics.utils.models.hotspot import ReportClass
-from hydra_genetics.utils.io.hotspot import Reader
-from hydra_genetics.utils.io import utils
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/workflow/scripts/pindel_processing_add_missing_csq.py
+++ b/workflow/scripts/pindel_processing_add_missing_csq.py
@@ -11,6 +11,7 @@ def check_info_field(vcf_in, field="CSQ"):
     Check whether the annotation field "CSQ" is in the VCF header.
 
     :param vcf_in: Input VCF file.
+    :param field: the annotation field to check, default is "CSQ".
     :return: number of annotations in the CSQ field.
     """
     vcfobj = VariantFile(vcf_in, "r")
@@ -27,9 +28,9 @@ def add_missing_annotation(vcf_in, vcf_out, field="CSQ"):
     """
     Add missing annotation field to the VCF file and set all annotations to blank.
 
-    :param vcf_in:
-    :param vcf_out:
-    :param field:
+    :param vcf_in: input VCF file to check for missing CSQ field
+    :param vcf_out: corrected VCF file with added CSQ field where needed
+    :param field: the annotation field to check and add if missing, default is "CSQ".
     :return:
     """
     nb_annot = check_info_field(vcf_in, field=field)
@@ -40,7 +41,6 @@ def add_missing_annotation(vcf_in, vcf_out, field="CSQ"):
         logger.info("Opening output vcf: {}".format(vcf_out))
         with VariantFile(vcf_out, 'w', header=vcfobj.header) as vcfobjout:
             for variant in variants:
-                # print(f"{variant.chrom}\t{variant.pos}\t{variant.id}\t{variant.ref}\t{variant.alts}\t{variant.qual}")
                 field_value = variant.info.get(field, None)
                 if field_value is None:
                     logger.info(f"Field {field} is missing in variant {variant.chrom}:{variant.pos}. Adding it now.")

--- a/workflow/scripts/pindel_processing_add_missing_csq.py
+++ b/workflow/scripts/pindel_processing_add_missing_csq.py
@@ -1,0 +1,68 @@
+from collections import OrderedDict
+import gzip
+import logging
+from pysam import VariantFile
+
+from hydra_genetics.utils.io.chr import ChrTranslater
+from hydra_genetics.utils.models.hotspot import MultiBpVariantData
+from hydra_genetics.utils.models.hotspot import ReportClass
+from hydra_genetics.utils.io.hotspot import Reader
+from hydra_genetics.utils.io import utils
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def check_info_field(vcf_in, field="CSQ"):
+    """
+    Check whether the annotation field "CSQ" is in the VCF header.
+
+    :param vcf_in: Input VCF file.
+    :return: number of annotations in the CSQ field.
+    """
+    vcfobj = VariantFile(vcf_in, "r")
+    header = vcfobj.header  # Requires to index the VCF file first if gzipped, set index file as input in smk rule
+    if field in header.info.keys():
+        logger.info(f"Field {field} is present in the VCF header.")
+        return len(header.info[field].description.split("Format: ")[-1].split('|'))
+    else:
+        logger.warning(f"Field {field} is NOT present in the VCF header.")
+        return 0
+
+
+def add_missing_annotation(vcf_in, vcf_out, field="CSQ"):
+    """
+    Add missing annotation field to the VCF file and set all annotations to blank.
+
+    :param vcf_in:
+    :param vcf_out:
+    :param field:
+    :return:
+    """
+    nb_annot = check_info_field(vcf_in, field=field)
+    if nb_annot:
+        logger.info(f"Field {field} is present in the VCF header. All variants must have INFO/CSQ.")
+        vcfobj = VariantFile(vcf_in, "r")
+        variants = vcfobj.fetch()
+        logger.info("Opening output vcf: {}".format(vcf_out))
+        with VariantFile(vcf_out, 'w', header=vcfobj.header) as vcfobjout:
+            for variant in variants:
+                # print(f"{variant.chrom}\t{variant.pos}\t{variant.id}\t{variant.ref}\t{variant.alts}\t{variant.qual}")
+                field_value = variant.info.get(field, None)
+                if field_value is None:
+                    logger.info(f"Field {field} is missing in variant {variant.chrom}:{variant.pos}. Adding it now.")
+                    blank_csq = [""] * nb_annot
+                    variant.info.update({"CSQ": "|".join(blank_csq)})
+                    print(f"{variant.info[field]}")
+                    print(variant.info.items())
+                vcfobjout.write(variant)
+        logger.info("Closing output vcf: {}".format(vcf_out))
+
+
+if __name__ == "__main__":
+    log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+    annotated = check_info_field(snakemake.input.vcf, field=snakemake.params.field)
+    if annotated:
+        add_missing_annotation(snakemake.input.vcf, snakemake.output.vcf, snakemake.params.field)


### PR DESCRIPTION
Fixes an edge case: If Pindel calls a variant with a N-base in the sequence of the alternate allele, VEP consider the alternate allele as null and skip the variant. The CSQ info field is then missing for the variant, which makes the downstream variant filtering fail. 
A blank CSQ is written as "CSQ=|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||".