### PR TITLE
fix: add new tabix rule for normal_db.vcf.gz

### DIFF
--- a/workflow/Snakefile_references.smk
+++ b/workflow/Snakefile_references.smk
@@ -101,6 +101,19 @@ use rule purecn_bam_list from references as references_purecn_bam_list with:
     input:
         bam_list=get_bams(),
 
+rule references_tabix_bcftools_merge:
+    input:
+        "references/bcftools_merge/normal_db.vcf.gz",
+    output:
+        "references/bcftools_merge/normal_db.vcf.gz.tbi",
+    log:
+        "references/bcftools_merge/normal_db.vcf.gz.tbi.log",
+    container:
+        config.get("bcftools_merge", {}).get("container", config["default_container"])
+    conda:
+        "rules/envs/purecn.yaml"
+    shell:
+        "tabix -p vcf {input} &> {log}"
 
 use rule bcftools_merge from references as references_bcftools_merge with:
     input:

--- a/workflow/Snakefile_references.smk
+++ b/workflow/Snakefile_references.smk
@@ -102,21 +102,6 @@ use rule purecn_bam_list from references as references_purecn_bam_list with:
         bam_list=get_bams(),
 
 
-rule references_tabix_bcftools_merge:
-    input:
-        "references/bcftools_merge/normal_db.vcf.gz",
-    output:
-        "references/bcftools_merge/normal_db.vcf.gz.tbi",
-    log:
-        "references/bcftools_merge/normal_db.vcf.gz.tbi.log",
-    conda:
-        "rules/envs/purecn.yaml"
-    container:
-        config.get("bcftools_merge", {}).get("container", config["default_container"])
-    shell:
-        "tabix -p vcf {input} &> {log}"
-
-
 use rule bcftools_merge from references as references_bcftools_merge with:
     input:
         vcfs=get_vcfs(),

--- a/workflow/Snakefile_references.smk
+++ b/workflow/Snakefile_references.smk
@@ -101,6 +101,7 @@ use rule purecn_bam_list from references as references_purecn_bam_list with:
     input:
         bam_list=get_bams(),
 
+
 rule references_tabix_bcftools_merge:
     input:
         "references/bcftools_merge/normal_db.vcf.gz",
@@ -108,12 +109,13 @@ rule references_tabix_bcftools_merge:
         "references/bcftools_merge/normal_db.vcf.gz.tbi",
     log:
         "references/bcftools_merge/normal_db.vcf.gz.tbi.log",
-    container:
-        config.get("bcftools_merge", {}).get("container", config["default_container"])
     conda:
         "rules/envs/purecn.yaml"
+    container:
+        config.get("bcftools_merge", {}).get("container", config["default_container"])
     shell:
         "tabix -p vcf {input} &> {log}"
+
 
 use rule bcftools_merge from references as references_bcftools_merge with:
     input:

--- a/workflow/rules/reference_rules.smk
+++ b/workflow/rules/reference_rules.smk
@@ -36,3 +36,35 @@ rule reference_rules_create_artifact_file_pindel:
         "{rule}: create artifact PoN for pindel"
     script:
         "../scripts/create_artifact_file_pindel.py"
+
+rule references_tabix_bcftools_merge:
+    input:
+        "references/bcftools_merge/normal_db.vcf.gz",
+    output:
+        "references/bcftools_merge/normal_db.vcf.gz.tbi",
+    log:
+        "references/bcftools_merge/normal_db.vcf.gz.tbi.log",
+    benchmark:
+        repeat(
+            "references/bcftools_merge/normal_db.vcf.gz.tbi.benchmark.tsv",
+            config.get("references_tabix_bcftools_merge", {}).get("benchmark_repeats", 1),
+        )
+    container:
+        config.get("references_tabix_bcftools_merge", {}).get("container", config["default_container"])
+    threads: config.get("references_tabix_bcftools_merge", {}).get("threads", config["default_resources"]["threads"])
+    resources:
+        mem_mb=config.get("references_tabix_bcftools_merge", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
+        mem_per_cpu=config.get("references_tabix_bcftools_merge", {}).get(
+            "mem_per_cpu", config["default_resources"]["mem_per_cpu"]
+        ),
+        partition=config.get("references_tabix_bcftools_merge", {}).get(
+            "partition", config["default_resources"]["partition"]
+        ),
+        threads=config.get("references_tabix_bcftools_merge", {}).get(
+            "threads", config["default_resources"]["threads"]
+        ),
+        time=config.get("references_tabix_bcftools_merge", {}).get("time", config["default_resources"]["time"]),
+    message:
+        "{rule}: index bcftools merge normal db vcf"
+    shell:
+        "tabix -p vcf {input} &> {log}"

--- a/workflow/rules/reference_rules.smk
+++ b/workflow/rules/reference_rules.smk
@@ -37,7 +37,7 @@ rule reference_rules_create_artifact_file_pindel:
     script:
         "../scripts/create_artifact_file_pindel.py"
 
-rule references_tabix_bcftools_merge:
+rule reference_rules_tabix_bcftools_merge:
     input:
         "references/bcftools_merge/normal_db.vcf.gz",
     output:

--- a/workflow/rules/reference_rules.smk
+++ b/workflow/rules/reference_rules.smk
@@ -37,6 +37,7 @@ rule reference_rules_create_artifact_file_pindel:
     script:
         "../scripts/create_artifact_file_pindel.py"
 
+
 rule reference_rules_tabix_bcftools_merge:
     input:
         "references/bcftools_merge/normal_db.vcf.gz",
@@ -57,12 +58,8 @@ rule reference_rules_tabix_bcftools_merge:
         mem_per_cpu=config.get("references_tabix_bcftools_merge", {}).get(
             "mem_per_cpu", config["default_resources"]["mem_per_cpu"]
         ),
-        partition=config.get("references_tabix_bcftools_merge", {}).get(
-            "partition", config["default_resources"]["partition"]
-        ),
-        threads=config.get("references_tabix_bcftools_merge", {}).get(
-            "threads", config["default_resources"]["threads"]
-        ),
+        partition=config.get("references_tabix_bcftools_merge", {}).get("partition", config["default_resources"]["partition"]),
+        threads=config.get("references_tabix_bcftools_merge", {}).get("threads", config["default_resources"]["threads"]),
         time=config.get("references_tabix_bcftools_merge", {}).get("time", config["default_resources"]["time"]),
     message:
         "{rule}: index bcftools merge normal db vcf"

--- a/workflow/schemas/config_references.schema.yaml
+++ b/workflow/schemas/config_references.schema.yaml
@@ -25,6 +25,16 @@ properties:
       path to yaml file containing compute resource configuration
     format: uri-reference
 
+  bcftools_merge:
+    type: object
+    description: config for the bcftools_merge rule
+    properties:
+      container:
+        type: string
+        description: >
+          uri pointing to docker/apptainer image that should be used
+        format: uri-reference
+
   svdb_export:
     type: object
     description: >

--- a/workflow/schemas/resources.schema.yaml
+++ b/workflow/schemas/resources.schema.yaml
@@ -117,6 +117,32 @@ properties:
         type: string
         description: parameters that should be forwarded
 
+  reference_rules_tabix_bcftools_merge:
+    type: object
+    description: parameters for reference_rules_tabix_bcftools_merge
+    properties:
+      benchmark_repeats:
+        type: integer
+        description: set number of times benchmark should be repeated
+      container:
+        type: string
+        description: name or path to docker/singularity container
+      mem_mb:
+        type: integer
+        description: max memory in MB to be available
+      mem_per_cpu:
+        type: integer
+        description: memory in MB used per cpu
+      partition:
+        type: string
+        description: partition to use on cluster
+      threads:
+        type: integer
+        description: number of threads to be available
+      time:
+        type: string
+        description: max execution time
+
   svdb_merge:
     type: object
     description: resource definitions for svdb_merge_wo_priority

--- a/workflow/schemas/rules.schema.yaml
+++ b/workflow/schemas/rules.schema.yaml
@@ -118,6 +118,25 @@ properties:
             type: string
             description: tsv file with chr, pos, svtype, median, sd, num_obs of detected variants
 
+  references_tabix_bcftools_merge:
+    type: object
+    description: rule to create a tabix index for the bcftools_merge normal_db vcf
+    properties:
+      input:
+        type: object
+        description: list of inputs
+        properties:
+          vcf:
+            type: string
+            description: gzipped vcf file to be indexed
+      output:
+        type: object
+        description: list of outputs
+        properties:
+          tbi:
+            type: string
+            description: tabix index for the input vcf
+
   svdb_merge_wo_priority:
     type: object
     description: input and output parameters for svdb_merge_wo_priority

--- a/workflow/schemas/rules.schema.yaml
+++ b/workflow/schemas/rules.schema.yaml
@@ -118,7 +118,7 @@ properties:
             type: string
             description: tsv file with chr, pos, svtype, median, sd, num_obs of detected variants
 
-  references_tabix_bcftools_merge:
+  reference_rules_tabix_bcftools_merge:
     type: object
     description: rule to create a tabix index for the bcftools_merge normal_db vcf
     properties:


### PR DESCRIPTION
Fix https://github.com/genomic-medicine-sweden/poppy/issues/99

Tabix error in references pipeline
```shell
snakemake --snakefile $POPPY_HOME/workflow/Snakefile_references.smk --profile $POPPY_HOME/profiles/grid_engine/ --configfiles  $POPPY_HOME/config/config_GRCh38.yaml $POPPY_HOME/config/config_references_pipeline_GRCh38.yaml  --config POPPY_HOME=$POPPY_HOME
Using profile /clinical/dev/cgg-cancer/poppy/poppy_v2.0.0/profiles/grid_engine/ for setting default command line arguments.
WARNING: merge_cnv_json: cancer_genes not specified. Gene coloring will be disabled in the report.
Building DAG of jobs...
MissingInputException in rule references_purecn_normal_db in file https://raw.githubusercontent.com/hydra-genetics/references/f0aa9bc/workflow/rules/purecn_panel_of_normal.smk, line 182:
Missing input files for rule references_purecn_normal_db:
    output: references/purecn_normal_db/output/normalDB.rds, references/purecn_normal_db/output/mapping_bias.rds, references/purecn_normal_db/output                                                                                          affected files:                                                                                                          references/bcftools_merge/normal_db.vcf.gz.tbi
``` 

Fix: add to `workflow/Snakefile_references.smk`
```python
rule references_tabix_bcftools_merge:
    input:
        "references/bcftools_merge/normal_db.vcf.gz",
    output:
        "references/bcftools_merge/normal_db.vcf.gz.tbi",
    log:
        "references/bcftools_merge/normal_db.vcf.gz.tbi.log",
    container:
        config.get("bcftools_merge", {}).get("container", config["default_container"])
    conda:
        "rules/envs/purecn.yaml"
    shell:
        "tabix -p vcf {input} &> {log}"
``` 

Update 30 June 2026: changed approach, see changes