### PR TITLE
fix: new rule for cnvkit_batch

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -67,7 +67,46 @@ module cnv_sv:
         config
 
 
-use rule * from cnv_sv as cnv_sv_*
+use rule * from cnv_sv exclude cnvkit_batch as cnv_sv_*
+
+
+rule cnv_sv_cnvkit_batch:
+    input:
+        bam="alignment/samtools_merge_bam/{sample}_{type}.bam",
+        bai="alignment/samtools_merge_bam/{sample}_{type}.bam.bai",
+        reference=config.get("cnvkit_batch", {}).get("normal_reference"),
+    output:
+        antitarget_coverage=temp("cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.antitargetcoverage.cnn"),
+        bins=temp("cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.bintest.cns"),
+        regions=temp("cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.cnr"),
+        segments=temp("cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.cns"),
+        segments_called=temp("cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.call.cns"),
+        target_coverage=temp("cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.targetcoverage.cnn"),
+    log:
+        "cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.call.cns.log",
+    benchmark:
+        repeat(
+            "cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.call.cns.benchmark.tsv",
+            config.get("cnvkit_batch", {}).get("benchmark_repeats", 1),
+        )
+    container:
+        config.get("cnvkit_batch", {}).get("container", config["default_container"])
+    threads: config.get("cnvkit_batch", {}).get("threads", config["default_resources"]["threads"])
+    resources:
+        mem_mb=config.get("cnvkit_batch", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
+        mem_per_cpu=config.get("cnvkit_batch", {}).get("mem_per_cpu", config["default_resources"]["mem_per_cpu"]),
+        partition=config.get("cnvkit_batch", {}).get("partition", config["default_resources"]["partition"]),
+        threads=config.get("cnvkit_batch", {}).get("threads", config["default_resources"]["threads"]),
+        time=config.get("cnvkit_batch", {}).get("time", config["default_resources"]["time"]),
+    params:
+        extra=config.get("cnvkit_batch", {}).get("extra", ""),
+        method=config.get("cnvkit_batch", {}).get("method", "hybrid"),
+    shell:
+        "(cnvkit.py batch {input.bam} "
+        "--reference {input.reference} "
+        "--method {params.method} "
+        "--output-dir cnv_sv/cnvkit_batch/{wildcards.sample}/ "
+        "{params.extra}) &> {log}"
 
 
 use rule cnvkit_call from cnv_sv as cnv_sv_cnvkit_call with:

--- a/workflow/Snakefile_references.smk
+++ b/workflow/Snakefile_references.smk
@@ -38,7 +38,7 @@ use rule gatk_denoise_read_counts from cnv_sv as cnv_sv_gatk_denoise_read_counts
         hdf5Tumor="cnv_sv/gatk_collect_read_counts/{sample}_{type}.counts.hdf5",
 
 
-use rule cnvkit_batch from cnv_sv as cnv_sv_cnvkit_batch with:
+use rule cnv_sv_cnvkit_batch from pipeline with:
     input:
         bam="alignment/samtools_merge_bam/{sample}_{type}.bam",
         bai="alignment/samtools_merge_bam/{sample}_{type}.bam.bai",

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -238,17 +238,23 @@ properties:
     description: >
       Configuration for the cnvkit_batch rule
     properties:
+      benchmark_repeats:
+        type: integer
+        description: set number of times benchmark should be repeated
       container:
         type: string
         description: >
           Name or path to container containing cnvkit executable
         format: uri-reference
-      normal_reference:
+      extra:
         type: string
-        description: >
-          Path to cnvkit normal reference file (.cnn), generated with reference pipeline
-        format: uri-reference
-        pattern: "\\.cnn$"
+        description: extra parameters to pass to cnvkit.py batch
+      mem_mb:
+        type: integer
+        description: max memory in MB to be available
+      mem_per_cpu:
+        type: integer
+        description: memory in MB used per cpu
       method:
         type: string
         description: >
@@ -263,6 +269,15 @@ properties:
           Path to cnvkit normal reference file (.cnn), generated with reference pipeline
         format: uri-reference
         pattern: "\\.cnn$"
+      partition:
+        type: string
+        description: partition to use on cluster
+      threads:
+        type: integer
+        description: number of threads to be available
+      time:
+        type: string
+        description: max execution time
     required:
       - method
       - normal_reference

--- a/workflow/schemas/resources.schema.yaml
+++ b/workflow/schemas/resources.schema.yaml
@@ -22,6 +22,26 @@ properties:
         type: string
         description: default max execution time for a rule
 
+  cnvkit_batch:
+    type: object
+    description: resource definitions for cnvkit_batch
+    properties:
+      mem_mb:
+        type: integer
+        description: max memory in MB to be available
+      mem_per_cpu:
+        type: integer
+        description: memory in MB used per cpu
+      partition:
+        type: string
+        description: partition to use on cluster
+      threads:
+        type: integer
+        description: number of threads to be available
+      time:
+        type: string
+        description: max execution time
+
   pindel_processing_add_missing_csq:
     type: object
     description: resource definitions for pindel_processing_add_missing_csq

--- a/workflow/schemas/rules.schema.yaml
+++ b/workflow/schemas/rules.schema.yaml
@@ -2,6 +2,46 @@ $schema: "http://json-schema.org/draft-04/schema#"
 description: snakemake rule input and output files description file
 type: object
 properties:
+  cnv_sv_cnvkit_batch:
+    type: object
+    description: rule to run cnvkit batch on a sample using a pre-built normal reference
+    properties:
+      input:
+        type: object
+        description: list of inputs
+        properties:
+          bam:
+            type: string
+            description: merged bam file for the sample
+          bai:
+            type: string
+            description: bai index for the input bam
+          reference:
+            type: string
+            description: cnvkit normal reference file (.cnn)
+      output:
+        type: object
+        description: list of outputs
+        properties:
+          antitarget_coverage:
+            type: string
+            description: antitarget coverage cnn file
+          bins:
+            type: string
+            description: bin-level copy number segment test file (.cns)
+          regions:
+            type: string
+            description: bin-level log2 copy ratios (.cnr)
+          segments:
+            type: string
+            description: segmented copy number file (.cns)
+          segments_called:
+            type: string
+            description: called copy number segments (.call.cns)
+          target_coverage:
+            type: string
+            description: target coverage cnn file
+
   pindel_processing_add_missing_csq:
     type: object
     description: rule to add any missing CSQ-field to a vep annotated pindel-vcf


### PR DESCRIPTION
Fix: https://github.com/genomic-medicine-sweden/poppy/issues/99

cnvkit_batch silent failure

- Job reported "completed successfully" by Snakemake
- Zero-byte log file
- Empty output directory
- No cluster error logs
- Confirmed cnvkit works standalone inside the container, ruling out a cnvkit issue
- Read the wrapper code from v9.2.0/bio/cnvkit/batch/wrapper.py — first line after imports is from snakemake_wrapper_utils.snakemake import move_files
- Checked snakemake_wrapper_utils inside the container:
```python
>>> from snakemake_wrapper_utils.snakemake import move_files
ImportError: cannot import name 'move_files' from 'snakemake_wrapper_utils.snakemake'
``` 
- Confirmed move_files was added to snakemake_wrapper_utils on 2025-09-09, after the hydragenetics/cnvkit:0.9.9 container was built
- Confirmed snakemake_wrapper_utils was not installed in poppy_env either

Fix: Exclude cnvkit_batch from the cnv_sv module in workflow/Snakefile and replace it with a standalone rule using a direct shell: 
1. Change use rule * from cnv_sv as cnv_sv_* to use rule * from cnv_sv exclude cnvkit_batch as cnv_sv_*
2. Add standalone rule cnv_sv_cnvkit_batch with shell: calling cnvkit.py batch directly
3. In Snakefile_references.smk replace `use rule cnvkit_batch from cnv_sv` with use `rule cnv_sv_cnvkit_batch from pipeline with`