### PR TITLE
fix: update rule order for snv_indels_bgzip in Snakefile

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -10,6 +10,7 @@ __license__ = "GPL-3"
 ruleorder: pindel_processing_annotation_vep > annotation_vep
 ruleorder: pindel_processing_artifact_annotation > annotation_artifact_annotation
 ruleorder: svdb_merge_wo_priority > cnv_sv_svdb_merge
+ruleorder: snv_indels_bgzip > cnv_sv_bgzip
 
 
 include: "rules/common.smk"


### PR DESCRIPTION
Fix: https://github.com/genomic-medicine-sweden/poppy/issues/99 
Both cnv_sv and snv_indels modules export a bgzip rule with an identical wildcard pattern ({file}.vcf → {file}.vcf.gz), causing Snakemake to fail with ambiguous rule errors for svdb_merge outputs.

- Workflow configuration:
  * Added a `ruleorder` statement to prioritize the `snv_indels_bgzip` rule over `cnv_sv_bgzip` in `Snakefile`.