### PR TITLE
chore: bump cnvkit container version from 0.9.9 to 0.9.13

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -57,15 +57,15 @@ cnv_html_report:
   show_table: true
 
 cnvkit_batch:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
   normal_reference: "{{REFERENCE_DIRECTORY}}/reference_files/cnvkit.PoN.cnn"
   method: hybrid
 
 cnvkit_call:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
 
 cnvkit_vcf:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
   hom_del_limit: 0.47
   het_del_limit: 1.68
   dup_limit: 2.3

--- a/config/config_GRCh38.yaml
+++ b/config/config_GRCh38.yaml
@@ -215,16 +215,16 @@ cnv_html_report:
   show_table: true
 
 cnvkit_batch:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
   normal_reference: "{{POPPY_HOME}}/reference_files/cnvkit.PoN.cnn" # created by the ref pipeline
   method: hybrid
   extra: ""
 
 cnvkit_call:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
 
 cnvkit_vcf:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
   hom_del_limit: 0.47
   het_del_limit: 1.68 
   dup_limit: 2.3 

--- a/config/config_hg19.yaml
+++ b/config/config_hg19.yaml
@@ -106,16 +106,16 @@ cnv_html_report:
   show_table: true
 
 cnvkit_batch:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
   normal_reference: "{{POPPY_HOME}}/reference_files/cnvkit.PoN.cnn" # created by the ref pipeline
   method: hybrid
   extra: ""
 
 cnvkit_call:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
 
 cnvkit_vcf:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
   hom_del_limit: 0.47
   het_del_limit: 1.68 # changed the value according to our config
   dup_limit: 2.3 # changed the value according to our config

--- a/config/config_references_pipeline_GRCh38.yaml
+++ b/config/config_references_pipeline_GRCh38.yaml
@@ -12,13 +12,13 @@ bed_to_interval_list:
   container: docker://hydragenetics/gatk4:4.2.2.0
 
 cnvkit_build_normal_reference:
-  container: docker://hydragenetics/cnvkit:0.9.9
+  container: docker://hydragenetics/cnvkit:0.9.13
 
 cnvkit_create_targets:
-  container: docker://hydragenetics/cnvkit:0.9.9
+  container: docker://hydragenetics/cnvkit:0.9.13
 
 cnvkit_create_anti_targets:
-  container: docker://hydragenetics/cnvkit:0.9.9
+  container: docker://hydragenetics/cnvkit:0.9.13
 
 collect_read_counts:
   container: docker://hydragenetics/gatk4:4.2.2.0

--- a/config/config_references_pipeline_hg19.yaml
+++ b/config/config_references_pipeline_hg19.yaml
@@ -13,13 +13,13 @@ bed_to_interval_list:
   container: docker://hydragenetics/gatk4:4.2.2.0
 
 cnvkit_build_normal_reference:
-  container: docker://hydragenetics/cnvkit:0.9.9
+  container: docker://hydragenetics/cnvkit:0.9.13
 
 cnvkit_create_targets:
-  container: docker://hydragenetics/cnvkit:0.9.9
+  container: docker://hydragenetics/cnvkit:0.9.13
 
 cnvkit_create_anti_targets:
-  container: docker://hydragenetics/cnvkit:0.9.9
+  container: docker://hydragenetics/cnvkit:0.9.13
 
 collect_read_counts:
   container: docker://hydragenetics/gatk4:4.2.2.0

--- a/docs/cnvs.md
+++ b/docs/cnvs.md
@@ -26,7 +26,7 @@ Calculates copy number segmentation from targeted sequencing read depths using [
 
 | Item      | Value                                                                                                       |
 | --------- | ----------------------------------------------------------------------------------------------------------- |
-| Container | `hydragenetics/cnvkit:0.9.9`                                                                                |
+| Container | `hydragenetics/cnvkit:0.9.13`                                                                                |
 | Input     | `alignment/samtools_merge_bam/{sample}_{type}.bam`                                                          |
 | Input     | `snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.vcf.gz` |
 | Output    | `cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.cns`                                                          |
@@ -141,7 +141,7 @@ The relevant sections in `config.yaml` governing CNV calling, SVDB merging, Pind
 
 ```yaml
 cnvkit_batch:
-  container: "docker://hydragenetics/cnvkit:0.9.9"
+  container: "docker://hydragenetics/cnvkit:0.9.13"
   normal_reference: "{{REFERENCE_DIRECTORY}}/reference_files/cnvkit.PoN.cnn"
   method: hybrid
 


### PR DESCRIPTION
This pull request updates the CNVkit Docker container version from `0.9.9` to `0.9.13` across all configuration files and documentation. Version 0.9.9 didn't have move_files from snakemake_wrapper_utils, which is needed for the cnvkit snakemake wrappers 
Fix: https://github.com/genomic-medicine-sweden/poppy/issues/99

**Configuration updates:**

* Updated the CNVkit container version to `0.9.13` in the main pipeline configuration files: `config.yaml`, `config_GRCh38.yaml`, and `config_hg19.yaml` for all CNVkit steps (batch, call, vcf). [[1]](diffhunk://#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaL60-R68) [[2]](diffhunk://#diff-b20bce67bfe8237b192f700b23ecb5a809769b0befa62ba5a707fc6af5c191f0L218-R227) [[3]](diffhunk://#diff-c5906b2878a2d330112c4b9ce299eb5b0b010de5c030d5bb9685e1108994c036L109-R118)
* Updated the CNVkit container version to `0.9.13` in the reference pipeline configuration files: `config_references_pipeline_GRCh38.yaml` and `config_references_pipeline_hg19.yaml` for all CNVkit steps (build_normal_reference, create_targets, create_anti_targets). [[1]](diffhunk://#diff-f19aa7b83b3af330125a65e9e8b0bad47eda544b5046f10a95e5ba77d4fa6a15L15-R21) [[2]](diffhunk://#diff-3a9dff2d855be39a9dbda72924d70af932cc4878920e8661b959248e7a285607L16-R22)

**Documentation updates:**

* Updated all references to the CNVkit container version in the documentation (`docs/cnvs.md`) to `0.9.13` for clarity and consistency. [[1]](diffhunk://#diff-3c83f380c8824f9b3335185cca8607a40872c876392c6f2eced361d5c0cbc231L29-R29) [[2]](diffhunk://#diff-3c83f380c8824f9b3335185cca8607a40872c876392c6f2eced361d5c0cbc231L144-R144)