### PR TITLE
fix: FFPE pindel insert size

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -166,6 +166,10 @@ picard_collect_insert_size_metrics:
 picard_mark_duplicates:
   container: "docker://hydragenetics/picard:2.25.0"
 
+normalize_pindel_insert_size_metrics:
+  min_insert_size: 200
+  replace_insert_size: 250
+
 pindel_call:
   container: "docker://hydragenetics/pindel:0.2.5b9"
   extra: "-x 2 -B 60" #x och B?

--- a/config/config_GRCh38.yaml
+++ b/config/config_GRCh38.yaml
@@ -8,6 +8,16 @@ default_container: "docker://hydragenetics/common:1.10.2"
 
 trimmer_software: "fastp_pe"
 
+modules:
+  alignment: v0.5.1
+  annotation: v1.0.0
+  cnv_sv: v3.1.0
+  filtering: v0.3.0
+  prealignment: v1.2.0
+  qc: v0.4.1
+  reports: v1.1.1
+  snv_indels_gms: v0.6.0
+
 reference:
   fasta: "{{POPPY_HOME}}/initial_references/ref_data/genome/GRCh38/human_GRCh38_no_alt_analysis_set/human_GRCh38_no_alt_analysis_set.fasta"
   fai: "{{POPPY_HOME}}/initial_references/ref_data/genome/GRCh38/human_GRCh38_no_alt_analysis_set/human_GRCh38_no_alt_analysis_set.fasta.fai"
@@ -322,6 +332,10 @@ picard_collect_insert_size_metrics:
 
 picard_mark_duplicates:
   container: "docker://hydragenetics/picard:2.25.0"
+
+normalize_pindel_insert_size_metrics:
+  min_insert_size: 200
+  replace_insert_size: 250
 
 pindel_call:
   container: "docker://hydragenetics/pindel:0.2.5b9"

--- a/config/config_hg19.yaml
+++ b/config/config_hg19.yaml
@@ -214,6 +214,10 @@ picard_collect_insert_size_metrics:
 picard_mark_duplicates:
   container: "docker://hydragenetics/picard:2.25.0"
 
+normalize_pindel_insert_size_metrics:
+  min_insert_size: 200
+  replace_insert_size: 250
+
 pindel_call:
   container: "docker://hydragenetics/pindel:0.2.5b9"
   extra: "-x 2 -B 60" #x och B?

--- a/docs/cnvs.md
+++ b/docs/cnvs.md
@@ -56,6 +56,8 @@ Estimates tumor purity and ploidy, and integrates read depth with B-allele frequ
 
 Detects long insertions, deletions, and structural variants for a specific targeted set of myeloid genes using [Pindel](https://github.com/genome/pindel).
 
+Before calling, the Picard insert size metrics are checked by a local rule (`normalize_pindel_insert_size_metrics`). Pindel requires the insert size to exceed the read length; FFPE samples can have insert sizes shorter than read lengths due to DNA fragmentation, which would otherwise cause Pindel to crash. If the measured `MEDIAN_INSERT_SIZE` is below the configured threshold (`min_insert_size`), it is replaced with a safe fallback value (`replace_insert_size`) before being passed to `pindel_generate_config`.
+
 | Item      | Value                                                       |
 | --------- | ----------------------------------------------------------- |
 | Container | `hydragenetics/pindel:0.2.5b9`                              |
@@ -162,6 +164,10 @@ purecn:
   intervals: "{{REFERENCE_DIRECTORY}}/reference_files/purecn_targets_intervals.txt"
   mapping_bias_file: "{{REFERENCE_DIRECTORY}}/reference_files/purecn_mapping_bias.rds"
   extra: "--model betabin --post-optimize"
+
+normalize_pindel_insert_size_metrics:
+  min_insert_size: 200
+  replace_insert_size: 250
 
 pindel_call:
   container: "docker://hydragenetics/pindel:0.2.5b9"

--- a/docs/non_hydra_rules.md
+++ b/docs/non_hydra_rules.md
@@ -10,6 +10,30 @@ These are custom rules created for Poppy to process the output from Pindel so th
 
 ### :snake: Rule
 
+Pindel requires the insert size in its config to exceed the read length, otherwise it raises a fatal error and the pipeline stops. This becomes a problem for FFPE samples, where the insert size is often shorter than the read length due to DNA fragmentation. This rule reads the Picard insert size metrics and, when `MEDIAN_INSERT_SIZE` falls below the configured `min_insert_size`, replaces both `MEDIAN_INSERT_SIZE` and `MEAN_INSERT_SIZE` with `replace_insert_size`. The adjusted metrics file is then passed to `pindel_generate_config` instead of the raw one.
+
+!!! note
+    Pindel uses the insert size as padding when clustering reads and expanding breakpoint search regions. Setting it to a value above the read length allows the pipeline to proceed, but the result should be interpreted with caution for samples with very short insert sizes. Pindel's own FAQ recommends 500 as a safe default when the true insert size is unknown.
+
+#SNAKEMAKE_RULE_SOURCE__pindel_processing__normalize_pindel_insert_size_metrics#
+
+#### :left_right_arrow: input / output files
+
+#SNAKEMAKE_RULE_TABLE__pindel_processing__normalize_pindel_insert_size_metrics#
+
+### :wrench: Configuration
+
+#### Software settings (`config.yaml`)
+
+#CONFIGSCHEMA__normalize_pindel_insert_size_metrics#
+
+#### Resources settings (`resources.yaml`)
+
+#RESOURCESSCHEMA__normalize_pindel_insert_size_metrics#
+
+
+### :snake: Rule
+
 #SNAKEMAKE_RULE_SOURCE__pindel_processing__pindel_processing_annotation_vep#
 
 #### :left_right_arrow: input / output files

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -80,7 +80,7 @@ use rule cnvkit_call from cnv_sv as cnv_sv_cnvkit_call with:
 use rule pindel_generate_config from cnv_sv as cnv_sv_pindel_generate_config with:
     input:
         bam="alignment/samtools_merge_bam/{sample}_{type}.bam",
-        metrics="qc/picard_collect_insert_size_metrics/{sample}_{type}.insert_size_metrics.txt",
+        metrics="qc/picard_collect_insert_size_metrics/{sample}_{type}.insert_size_metrics.pindel_adjusted.txt",
 
 
 module filtering:

--- a/workflow/rules/pindel_processing.smk
+++ b/workflow/rules/pindel_processing.smk
@@ -4,14 +4,46 @@ __email__ = "arielle.munters@scilifelab.uu.se"
 __license__ = "GPL-3"
 
 
+rule normalize_pindel_insert_size_metrics:
+    input:
+        metrics="qc/picard_collect_insert_size_metrics/{sample}_{type}.insert_size_metrics.txt",
+    output:
+        metrics="qc/picard_collect_insert_size_metrics/{sample}_{type}.insert_size_metrics.pindel_adjusted.txt",
+    log:
+        "qc/picard_collect_insert_size_metrics/{sample}_{type}.insert_size_metrics.pindel_adjusted.log",
+    benchmark:
+        repeat(
+            "qc/picard_collect_insert_size_metrics/{sample}_{type}.insert_size_metrics.pindel_adjusted.benchmark.tsv",
+            config.get("normalize_pindel_insert_size_metrics", {}).get("benchmark_repeats", 1),
+        )
+    container:
+        config.get("pindel_call", {}).get("container", config["default_container"])
+    threads: config.get("normalize_pindel_insert_size_metrics", {}).get("threads", config["default_resources"]["threads"])
+    resources:
+        mem_mb=config.get("normalize_pindel_insert_size_metrics", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
+        mem_per_cpu=config.get("normalize_pindel_insert_size_metrics", {}).get(
+            "mem_per_cpu", config["default_resources"]["mem_per_cpu"]
+        ),
+        partition=config.get("normalize_pindel_insert_size_metrics", {}).get(
+            "partition", config["default_resources"]["partition"]
+        ),
+        threads=config.get("normalize_pindel_insert_size_metrics", {}).get("threads", config["default_resources"]["threads"]),
+        time=config.get("normalize_pindel_insert_size_metrics", {}).get("time", config["default_resources"]["time"]),
+    params:
+        min_insert_size=config.get("normalize_pindel_insert_size_metrics", {}).get("min_insert_size", 200),
+        replace_insert_size=config.get("normalize_pindel_insert_size_metrics", {}).get("replace_insert_size", 250),
+    message:
+        "{rule}: adjust insert size metrics for pindel when insert size is below configured threshold"
+    script:
+        "../scripts/normalize_pindel_insert_size_metrics.py"
+
+
 rule pindel_processing_add_missing_csq:
     input:
         vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.vcf.gz",
         tbi="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.vcf.gz.tbi",
     output:
         vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.csq_corrected.vcf",
-    params:
-        field="CSQ",
     log:
         "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.csq_corrected.vcf.log",
     benchmark:
@@ -19,6 +51,8 @@ rule pindel_processing_add_missing_csq:
             "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.csq_corrected.vcf.benchmark.tsv",
             config.get("pindel_processing_add_missing_csq", {}).get("benchmark_repeats", 1),
         )
+    container:
+        config.get("pindel_processing_add_missing_csq", {}).get("container", config["default_container"])
     threads: config.get("pindel_processing_add_missing_csq", {}).get("threads", config["default_resources"]["threads"])
     resources:
         mem_mb=config.get("pindel_processing_add_missing_csq", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
@@ -28,8 +62,8 @@ rule pindel_processing_add_missing_csq:
         partition=config.get("pindel_processing_add_missing_csq", {}).get("partition", config["default_resources"]["partition"]),
         threads=config.get("pindel_processing_add_missing_csq", {}).get("threads", config["default_resources"]["threads"]),
         time=config.get("pindel_processing_add_missing_csq", {}).get("time", config["default_resources"]["time"]),
-    container:
-        config.get("pindel_processing_add_missing_csq", {}).get("container", config["default_container"])
+    params:
+        field="CSQ",
     message:
         "{rule}: if need be, add missing CSQ annotation to variants in {input.vcf}"
     script:
@@ -44,9 +78,6 @@ rule pindel_processing_annotation_vep:
         vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vcf.gz",
     output:
         vcf=temp("cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.vcf"),
-    params:
-        extra=config.get("vep", {}).get("extra", "--pick"),
-        mode=config.get("vep", {}).get("mode", "--offline --cache --merged "),
     log:
         "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.vcf.log",
     benchmark:
@@ -54,6 +85,8 @@ rule pindel_processing_annotation_vep:
             "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.vcf.benchmark.tsv",
             config.get("vep", {}).get("benchmark_repeats", 1),
         )
+    container:
+        config.get("vep", {}).get("container", config["default_container"])
     threads: config.get("vep", {}).get("threads", config["default_resources"]["threads"])
     resources:
         mem_mb=config.get("vep", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
@@ -61,8 +94,9 @@ rule pindel_processing_annotation_vep:
         partition=config.get("vep", {}).get("partition", config["default_resources"]["partition"]),
         threads=config.get("vep", {}).get("threads", config["default_resources"]["threads"]),
         time=config.get("vep", {}).get("time", config["default_resources"]["time"]),
-    container:
-        config.get("vep", {}).get("container", config["default_container"])
+    params:
+        extra=config.get("vep", {}).get("extra", "--pick"),
+        mode=config.get("vep", {}).get("mode", "--offline --cache --merged "),
     message:
         "{rule}: vep annotate {input.vcf}"
     script:
@@ -83,6 +117,8 @@ rule pindel_processing_artifact_annotation:
             "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.normalized.vep_annotated.artifact_annotated.vcf.benchmark.tsv",
             config.get("pindel_processing_artifact_annotation", {}).get("benchmark_repeats", 1),
         )
+    container:
+        config.get("pindel_processing_artifact_annotation", {}).get("container", config["default_container"])
     threads: config.get("pindel_processing_artifact_annotation", {}).get("threads", config["default_resources"]["threads"])
     resources:
         mem_mb=config.get("pindel_processing_artifact_annotation", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
@@ -94,8 +130,6 @@ rule pindel_processing_artifact_annotation:
         ),
         threads=config.get("pindel_processing_artifact_annotation", {}).get("threads", config["default_resources"]["threads"]),
         time=config.get("pindel_processing_artifact_annotation", {}).get("time", config["default_resources"]["time"]),
-    container:
-        config.get("pindel_processing_artifact_annotation", {}).get("container", config["default_container"])
     message:
         "{rule}: add artifact annotation on {input.vcf}, based on arifact_panel_pindel.tsv "
     script:
@@ -114,6 +148,8 @@ rule pindel_processing_fix_af:
             "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.fix_af.vcf.benchmark.tsv",
             config.get("pindel_processing_fix_af", {}).get("benchmark_repeats", 1),
         )
+    container:
+        config.get("pindel_processing_fix_af", {}).get("container", config["default_container"])
     threads: config.get("pindel_processing_fix_af", {}).get("threads", config["default_resources"]["threads"])
     resources:
         mem_mb=config.get("pindel_processing_fix_af", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
@@ -121,8 +157,6 @@ rule pindel_processing_fix_af:
         partition=config.get("pindel_processing_fix_af", {}).get("partition", config["default_resources"]["partition"]),
         threads=config.get("pindel_processing_fix_af", {}).get("threads", config["default_resources"]["threads"]),
         time=config.get("pindel_processing_fix_af", {}).get("time", config["default_resources"]["time"]),
-    container:
-        config.get("pindel_processing_fix_af", {}).get("container", config["default_container"])
     message:
         "{rule}: add af and dp to info field in {input.vcf}"
     script:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -506,6 +506,17 @@ properties:
       - extra
       - include_bed
 
+  normalize_pindel_insert_size_metrics:
+    type: object
+    description: Configuration for normalize_pindel_insert_size_metrics rule
+    properties:
+      min_insert_size:
+        type: number
+        description: Minimum allowed insert size before replacement
+      replace_insert_size:
+        type: number
+        description: Insert size value used when below minimum threshold
+
   pindel_processing_add_missing_csq:
     type: object
     description: parameters for pindel_processing_add_missing_csq

--- a/workflow/schemas/resources.schema.yaml
+++ b/workflow/schemas/resources.schema.yaml
@@ -22,6 +22,26 @@ properties:
         type: string
         description: default max execution time for a rule
 
+  normalize_pindel_insert_size_metrics:
+    type: object
+    description: resource definitions for normalize_pindel_insert_size_metrics
+    properties:
+      mem_mb:
+        type: integer
+        description: max memory in MB to be available
+      mem_per_cpu:
+        type: integer
+        description: memory in MB used per cpu
+      partition:
+        type: string
+        description: partition to use on cluster
+      threads:
+        type: integer
+        description: number of threads to be available
+      time:
+        type: string
+        description: max execution time
+
   pindel_processing_add_missing_csq:
     type: object
     description: resource definitions for pindel_processing_add_missing_csq

--- a/workflow/schemas/rules.schema.yaml
+++ b/workflow/schemas/rules.schema.yaml
@@ -2,6 +2,25 @@ $schema: "http://json-schema.org/draft-04/schema#"
 description: snakemake rule input and output files description file
 type: object
 properties:
+  normalize_pindel_insert_size_metrics:
+    type: object
+    description: rule to normalize insert size metrics for pindel config generation
+    properties:
+      input:
+        type: object
+        description: list of inputs
+        properties:
+          metrics:
+            type: string
+            description: picard insert size metrics file
+      output:
+        type: object
+        description: list of outputs
+        properties:
+          metrics:
+            type: string
+            description: adjusted insert size metrics file for pindel
+
   pindel_processing_add_missing_csq:
     type: object
     description: rule to add any missing CSQ-field to a vep annotated pindel-vcf

--- a/workflow/scripts/normalize_pindel_insert_size_metrics.py
+++ b/workflow/scripts/normalize_pindel_insert_size_metrics.py
@@ -1,0 +1,50 @@
+        )
+
+    original_value = values[median_idx]
+    try:
+        insert_size = float(original_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"MEDIAN_INSERT_SIZE value '{original_value}' is not numeric in first data row."
+        ) from exc
+
+    changed = False
+    if insert_size < min_insert_size:
+        values[median_idx] = str(replace_insert_size)
+        values[mean_idx] = str(replace_insert_size)
+        lines[data_idx] = "\t".join(values) + "\n"
+        changed = True
+
+    return lines, changed, original_value
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        filename=snakemake.log[0],
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    min_insert_size = snakemake.params.min_insert_size
+    replace_insert_size = snakemake.params.replace_insert_size
+
+    input_path = Path(snakemake.input.metrics)
+    output_path = Path(snakemake.output.metrics)
+
+    logging.info(f"Reading insert size metrics from {input_path}")
+    lines = input_path.read_text().splitlines(keepends=True)
+    updated_lines, changed, original_value = normalize_insert_size(
+        lines, min_insert_size, replace_insert_size
+    )
+    output_path.write_text("".join(updated_lines))
+
+    if changed:
+        logging.info(
+            f"MEDIAN_INSERT_SIZE was below {min_insert_size} ({original_value}); "
+            f"adjusted to {replace_insert_size} for pindel input."
+        )
+    else:
+        logging.info(
+            f"MEDIAN_INSERT_SIZE was {original_value}; no adjustment needed."
+        )
+    logging.info(f"Wrote adjusted metrics to {output_path}")

--- a/workflow/scripts/normalize_pindel_insert_size_metrics.py
+++ b/workflow/scripts/normalize_pindel_insert_size_metrics.py
@@ -92,4 +92,3 @@ if __name__ == "__main__":
             f"MEDIAN_INSERT_SIZE was {original_value}; no adjustment needed."
         )
     logging.info(f"Wrote adjusted metrics to {output_path}")
-

--- a/workflow/scripts/normalize_pindel_insert_size_metrics.py
+++ b/workflow/scripts/normalize_pindel_insert_size_metrics.py
@@ -1,3 +1,47 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import logging
+
+
+def find_metrics_header(lines):
+    for idx, line in enumerate(lines):
+        stripped = line.rstrip("\n")
+        if stripped.startswith("MEDIAN_INSERT_SIZE\t") or stripped == "MEDIAN_INSERT_SIZE":
+            return idx
+    raise ValueError("Could not find Picard metrics header line starting with 'MEDIAN_INSERT_SIZE'.")
+
+
+def find_first_data_row(lines, header_idx):
+    for idx in range(header_idx + 1, len(lines)):
+        stripped = lines[idx].strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        return idx
+    raise ValueError("Could not find first data row after Picard metrics header.")
+
+
+def normalize_insert_size(lines, min_insert_size, replace_insert_size):
+    header_idx = find_metrics_header(lines)
+    data_idx = find_first_data_row(lines, header_idx)
+    header_line = lines[header_idx].rstrip("\n")
+    data_line = lines[data_idx].rstrip("\n")
+    headers = header_line.split("\t")
+    values = data_line.split("\t")
+
+    if "MEDIAN_INSERT_SIZE" not in headers:
+        raise ValueError("Header line does not contain 'MEDIAN_INSERT_SIZE' column.")
+    if "MEAN_INSERT_SIZE" not in headers:
+        raise ValueError("Header line does not contain 'MEAN_INSERT_SIZE' column.")
+
+    median_idx = headers.index("MEDIAN_INSERT_SIZE")
+    mean_idx = headers.index("MEAN_INSERT_SIZE")
+
+    if median_idx >= len(values):
+        raise ValueError(
+            "First data row after Picard metrics header does not contain enough columns "
+            "to match the header."
         )
 
     original_value = values[median_idx]
@@ -48,3 +92,4 @@ if __name__ == "__main__":
             f"MEDIAN_INSERT_SIZE was {original_value}; no adjustment needed."
         )
     logging.info(f"Wrote adjusted metrics to {output_path}")
+


### PR DESCRIPTION
Reason: at the Gothenburg node we want to process FFPE samples, which were crashing at the pindel steps due to the insert size.

This pull request introduces a new rule to normalize Picard insert size metrics before running Pindel, ensuring compatibility with samples that have short insert sizes (such as FFPE samples). The changes add configuration, documentation, and resource schema support for this rule, and update the pipeline to use the adjusted metrics file for Pindel. Several other minor improvements to rule definitions and container handling are also included. 

**Insert Size Normalization for Pindel:**

* Added a new Snakemake rule `normalize_pindel_insert_size_metrics` in `pindel_processing.smk` and implemented its logic in `normalize_pindel_insert_size_metrics.py`. This rule checks if the `MEDIAN_INSERT_SIZE` is below a configurable threshold and replaces it with a safe fallback value before passing it to Pindel, preventing pipeline crashes for FFPE samples. [[1]](diffhunk://#diff-4b8359a2f190f954770cd410725be8260725314d5c1e31fa852dd6f153c385c3R7-R55) [[2]](diffhunk://#diff-e888b8f9df1eebf6b904e9397205e66d38a6e4536540f2b23ac93f7d278fb64fR1-R50)
* Updated the pipeline (`Snakefile`) to use the adjusted insert size metrics file (`.pindel_adjusted.txt`) as input for Pindel config generation.
* Added configuration options for the new rule in `config.yaml`, `config_GRCh38.yaml`, and `config_hg19.yaml`, including `min_insert_size` and `replace_insert_size`. [[1]](diffhunk://#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaR169-R172) [[2]](diffhunk://#diff-b20bce67bfe8237b192f700b23ecb5a809769b0befa62ba5a707fc6af5c191f0R336-R339) [[3]](diffhunk://#diff-c5906b2878a2d330112c4b9ce299eb5b0b010de5c030d5bb9685e1108994c036R217-R220)
* Extended the documentation (`docs/cnvs.md` and `docs/non_hydra_rules.md`) to explain the rationale, configuration, and usage of the normalization rule. [[1]](diffhunk://#diff-3c83f380c8824f9b3335185cca8607a40872c876392c6f2eced361d5c0cbc231R59-R60) [[2]](diffhunk://#diff-3c83f380c8824f9b3335185cca8607a40872c876392c6f2eced361d5c0cbc231R168-R171) [[3]](diffhunk://#diff-7ecd1d8e8e87ab71a2c98aa30fea1c432e53563b77c81aa145393267d9969283R11-R34)

**Configuration and Resource Schema Updates:**

* Added schema definitions for the new rule in `config.schema.yaml`, `resources.schema.yaml`, and `rules.schema.yaml` to support configuration validation and resource management. [[1]](diffhunk://#diff-569f76ff237e3c9fd635b8d29b42c0f591c43e8e1f6a758a8bb5257b5f821d19R509-R519) [[2]](diffhunk://#diff-f6259f736a8e3b4adbea601fbc360f6a54901119e151a088974896065d02ecceR25-R44) [[3]](diffhunk://#diff-51f8dccbaa7c885bde924e1c607d6d29dfb66422293e3cce2be83d109861295bR5-R23)
